### PR TITLE
Replace Chalk by Picocolors

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "webpack": "^4.47.0"
   },
   "dependencies": {
-    "chalk": "^2.4.2",
     "consola": "^3.2.3",
     "error-stack-parser": "^2.1.4",
+    "picocolors": "^1.1.0",
     "string-width": "^4.2.3"
   },
   "jest": {

--- a/src/formatters/eslintError.js
+++ b/src/formatters/eslintError.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const concat = require('../utils').concat
-const chalk = require('chalk')
+const pc = require('picocolors')
 
 const infos = [
   'You may use special comments to disable some warnings.',
-  'Use ' + chalk.yellow('// eslint-disable-next-line') + ' to ignore the next line.',
-  'Use ' + chalk.yellow('/* eslint-disable */') + ' to ignore all warnings in a file.'
+  'Use ' + pc.yellow('// eslint-disable-next-line') + ' to ignore the next line.',
+  'Use ' + pc.yellow('/* eslint-disable */') + ' to ignore all warnings in a file.'
 ]
 
 function displayError (error) {

--- a/src/reporters/base.js
+++ b/src/reporters/base.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { colors, formatTitle, formatText, clearConsole } = require('../utils/log')
-const chalk = require('chalk')
+const pc = require('picocolors')
 const stringWidth = require('string-width')
 
 class BaseReporter {
@@ -45,7 +45,7 @@ class BaseReporter {
   appendTimestamp (title, message) {
     // Make timestamp appear at the end of the line
     const line = `${title} ${message}`
-    const dateString = chalk.grey(new Date().toLocaleTimeString())
+    const dateString = pc.gray(new Date().toLocaleTimeString())
     let logSpace = process.stdout.columns - stringWidth(line) - stringWidth(dateString)
     if (logSpace <= 0) {
       logSpace = 10

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const chalk = require('chalk')
+const pc = require('picocolors')
 
 const colors = {
   success: 'green',
@@ -32,11 +32,11 @@ function capitalizeFirstLetter (string) {
 }
 
 function formatTitle (severity, title) {
-  return chalk[bgColor(severity)].black('', title, '')
+  return pc[bgColor(severity)](pc.black(` ${title} `))
 }
 
 function formatText (severity, message) {
-  return chalk[textColor(severity)](message)
+  return pc[textColor(severity)](message)
 }
 
 function clearConsole () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5489,6 +5489,11 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picocolors@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.0.tgz#5358b76a78cde483ba5cef6a9dc9671440b27d59"
+  integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

No existing issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

This PR the dependency Chalk by Picolors, a more lightweight dependency, with less sub-dependencies, and also faster (thus this is not really significant here).

I don't believe we need ~88Kb and 6 sub-dependencies to display colors in terminal, picocolors is totally enough for our usages.

Less dependencies means less possible vulnerability security issues, we already saw a lot of "not so known" but over-used dependencies being discrelty modified to introduce malicious code. It also means a reduction of consumed bandwidth.

See https://npmgraph.js.org/?q=@nuxt/friendly-errors-webpack-plugin#select=exact%3Achalk%402.4.2 and the report below:

```
Package size report
===================

Package info for "@nuxt/friendly-errors-webpack-plugin@2.6.0": 19 MB
  Released: 2023-11-23 14:43:35.95 +0000 UTC (41w3d ago)
  Downloads last week: 156,930 (45.05%)
  Estimated traffic last week: 2.9 TB
  Subdependencies: 91

Removed dependencies:
  - chalk@2.4.2: 88 kB (0.47%)
    Downloads last week: 52,915,586 (N/A% from 2.4.2)
    Downloads last week from "@nuxt/friendly-errors-webpack-plugin@2.6.0": 156,930 (N/A%)
    Traffic last week: N/A
    Traffic from "@nuxt/friendly-errors-webpack-plugin@2.6.0": 2.9 TB (N/A%)
    Subdependencies: 6 (6.59%)

Added dependencies:
  + picocolors@1.1.0: 12 kB (0.06%)
    Downloads last week: 10,649,179 (N/A% from 1.1.0)
    Estimated traffic last week: N/A
    Subdependencies: 0 (0%)

Estimated new statistics:
  Package size: 19 MB → 370 kB (1.98%)
  Subdependencies: 91 → 9 (-82)
  Traffic with last week's downloads:
    For current version: 2.9 TB → 58 GB (2.9 TB saved)
    For all versions: 6.5 TB → 129 GB (6.4 TB saved)
```

Note, here we're using Chalk 2.4.2, which is 5 years old. It is not possible to use the latest version 5 (which has no sub-dependencies, and weighs less than 2.4.2) because it is ESM-compatible only.
Chalk therefore recommends using CJS-compatible version 4, but [it still weighs ~90KB and still has 5 sub-dependencies](https://npmgraph.js.org/?q=chalk%40%5E4#select=exact%3Achalk%404.1.2) :(

Thanks!